### PR TITLE
Improve map_to_vec

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -117,12 +117,10 @@ fn parse_overrides(path: &PathBuf, globs: Vec<&str>) -> overrides::Override {
 fn map_to_vec(map: FxHashMap<lang::Language, LangResult>) -> Vec<cli::LangOut> {
     let mut langs: Vec<_> = map
         .into_iter()
-        .map(|(key, val)| {
-            cli::LangOut {
-                language: key,
-                num_files: val.file_cnt,
-                num_lines: val.line_cnt,
-            }
+        .map(|(key, val)| cli::LangOut {
+            language: key,
+            num_files: val.file_cnt,
+            num_lines: val.line_cnt,
         })
         .collect();
     langs.sort_unstable_by(|a, b| a.num_lines.cmp(&b.num_lines).reverse());

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -115,15 +115,17 @@ fn parse_overrides(path: &PathBuf, globs: Vec<&str>) -> overrides::Override {
 }
 
 fn map_to_vec(map: FxHashMap<lang::Language, LangResult>) -> Vec<cli::LangOut> {
-    let mut langs = Vec::with_capacity(map.len());
-    for (key, val) in map.iter() {
-        langs.push(cli::LangOut {
-            language: *key,
-            num_files: val.file_cnt,
-            num_lines: val.line_cnt,
-        });
-    }
-    langs.sort_by(|a, b| a.num_lines.cmp(&b.num_lines).reverse());
+    let mut langs: Vec<_> = map
+        .into_iter()
+        .map(|(key, val)| {
+            cli::LangOut {
+                language: key,
+                num_files: val.file_cnt,
+                num_lines: val.line_cnt,
+            }
+        })
+        .collect();
+    langs.sort_unstable_by(|a, b| a.num_lines.cmp(&b.num_lines).reverse());
     langs
 }
 


### PR DESCRIPTION
This improves the function by consuming the original map, what will pre-alocate the final vector with the exact required memory implicitly. Using sort_unstable_by is generally faster, don't preserve the original order, but that's not important here.