### PR TITLE
Replace jemalloc with mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,30 +248,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "lines-cli"
@@ -281,7 +271,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ignore",
- "jemallocator",
+ "mimalloc",
  "num-format",
  "rustc-hash",
  "serde",
@@ -300,6 +290,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "num-format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,10 @@ bytecount = { version = "0.6" }
 clap = { version = "4.5", features = ["derive"] }
 crossbeam = { version = "0.8" }
 ignore = { version = "0.4" }
+mimalloc = { version = "0.1.47" }
 num-format = { version = "0.4" }
 rustc-hash = { version = "2.1.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 tabled = { version = "0.20" }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-jemallocator = { version = "0.5.4" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,8 @@ mod cli;
 mod fs;
 mod lang;
 
-#[cfg(not(target_os = "windows"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
     let start = Instant::now();


### PR DESCRIPTION
## Summary
- Replace jemallocator with mimalloc as the global allocator
- Remove Windows-specific conditional compilation for allocator
- Update Cargo.toml and main.rs to use mimalloc

## Test plan
- [x] Build succeeds with mimalloc
- [x] Code compiles without warnings
- [x] Dependencies updated correctly in Cargo.lock

🤖 Generated with [Claude Code](https://claude.ai/code)