### PR TITLE
Add --exclude flag for custom pattern filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "ignore",
  "mimalloc",
  "num-format",
+ "regex",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -365,6 +366,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ crossbeam = { version = "0.8.4" }
 ignore = { version = "0.4.23" }
 mimalloc = { version = "0.1.47" }
 num-format = { version = "0.4.4" }
+regex = { version = "1.11.1" }
 rustc-hash = { version = "2.1.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Arguments:
   [PATH]  Directory or file to scan [default: .]
 
 Options:
-  -o, --output <FORMAT>  Output format ("table" or "json") [default: table]
-  -t, --timing           Show timing information
-  -h, --help             Print help
-  -V, --version          Print version
+  -o, --output <FORMAT>    Output format ("table" or "json") [default: table]
+  -t, --timing             Show timing information
+  -e, --exclude <EXCLUDE>  Exclude regex patterns (can be used multiple times)
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 Using `lines` in this repo outputs:
@@ -38,6 +39,33 @@ Using `lines` in this repo outputs:
  TOML     |     1 |    36
 ---------- ------- -------
  Total    |     6 |   683
+```
+
+### Exclude Patterns
+
+You can exclude files and directories from the count using regex patterns with the `--exclude` flag:
+
+```bash
+# Exclude all test files (exact match)
+lines --exclude "^test$"
+
+# Exclude files containing "test" anywhere in the name
+lines --exclude "test"
+
+# Exclude multiple patterns
+lines --exclude "target" --exclude "\.git" --exclude "node_modules"
+
+# Exclude by file extension
+lines --exclude "\.log$" --exclude "\.tmp$"
+
+# Exclude files starting with "temp"
+lines --exclude "^temp"
+
+# Exclude hidden files (starting with .)
+lines --exclude "^\."
+
+# Complex pattern: exclude test files and directories
+lines --exclude "(test|spec)" --exclude ".*\.test\."
 ```
 
 ## License

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,10 @@ pub struct Args {
     #[clap(short, long)]
     pub timing: bool,
 
+    /// Exclude regex patterns (can be used multiple times).
+    #[clap(short = 'e', long = "exclude", action = clap::ArgAction::Append)]
+    pub exclude: Vec<String>,
+
     /// Directory or file to scan.
     #[clap(default_value = ".")]
     pub path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,13 @@ fn main() {
     let start = Instant::now();
     let opt = cli::get_options();
 
-    let langs = fs::visit_path_parallel(&opt.path);
+    let langs = match fs::visit_path_parallel(&opt.path, &opt.exclude) {
+        Ok(langs) => langs,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
 
     let total_num_files = langs.iter().map(|l| l.num_files).sum();
     let total_num_lines = langs.iter().map(|l| l.num_lines).sum();


### PR DESCRIPTION
## Summary
• Added a new `--exclude` flag that allows users to exclude files and directories from line counting using custom patterns
• The flag supports multiple exclusion patterns and can be used multiple times
• Patterns match against both full file paths and file names for flexible filtering

## Changes Made
• Added `--exclude/-e` flag to CLI arguments in `cli.rs`
• Implemented pattern matching logic in `fs.rs` with `should_exclude_path()` function
• Updated `visit_path_parallel()` to accept and use exclude patterns
• Modified `main.rs` to pass exclude patterns to the file system traversal
• Updated README with usage examples and documentation

## Test plan
- [x] Verified compilation with `cargo build`
- [x] Ran existing tests with `cargo test` - all pass
- [x] Tested exclude functionality with various patterns:
  - [x] Exclude by file extension (`.rs`, `.log`)
  - [x] Exclude by directory name (`target`, `.git`)
  - [x] Exclude by file name (`LICENSE`)
  - [x] Multiple exclusion patterns
- [x] Verified both table and JSON output formats work correctly
- [x] Updated help text shows the new flag correctly

🤖 Generated with [Claude Code](https://claude.ai/code)