### PR TITLE
fix: use as_str() in Language Display impl instead of Debug

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -165,7 +165,7 @@ impl serde::Serialize for Language {
 
 impl fmt::Display for Language {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        write!(f, "{}", self.as_str())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes `Language::Display` which incorrectly delegated to `fmt::Debug::fmt`, printing the Rust variant name (e.g. `Language::Rust`) instead of the human-readable name (e.g. `Rust`).

## Change

Replaced `fmt::Debug::fmt(self, f)` with `write!(f, "{}", self.as_str())` so `Display` stays in sync with `as_str()`.

## Validation

- `cargo check` passes cleanly
- The change is a one-line substitution with no other callers affected