### PR TITLE
fix: remove 16-byte extension length limit, use to_ascii_lowercase()

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -67,16 +67,8 @@ pub fn visit_path_parallel(
                 let Some(ext_str) = ext.to_str() else {
                     return WalkState::Continue;
                 };
-                let ext_bytes = ext_str.as_bytes();
-                let mut lower_buf = [0u8; 16];
-                if ext_bytes.len() > lower_buf.len() {
-                    return WalkState::Continue;
-                }
-                lower_buf[..ext_bytes.len()].copy_from_slice(ext_bytes);
-                lower_buf[..ext_bytes.len()].make_ascii_lowercase();
-                let lower_ext =
-                    unsafe { std::str::from_utf8_unchecked(&lower_buf[..ext_bytes.len()]) };
-                let Some(language) = lang::get_language(lower_ext) else {
+                let lower_ext = ext_str.to_ascii_lowercase();
+                let Some(language) = lang::get_language(&lower_ext) else {
                     return WalkState::Continue;
                 };
                 match lines_in_file(path, &mut buf) {


### PR DESCRIPTION
## Summary

Replaces the unsafe fixed-size 16-byte buffer for file extension lowercasing with the safe, standard `to_ascii_lowercase()` call.

## Problem

Files with extensions longer than 16 bytes were silently dropped from line counts with no warning — producing silently-wrong totals.

## Fix

- Removed the `unsafe { std::str::from_utf8_unchecked }` block and fixed buffer
- Replaced with a single `ext_str.to_ascii_lowercase()` call
- Correctly handles extensions of any length
- Compiles and passes existing tests