### PR TITLE
perf: increase read buffer from 32 KiB to 256 KiB

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -44,7 +44,7 @@ pub fn visit_path_parallel(
         .build_parallel()
         .run(|| {
             let patterns = Arc::clone(&compiled_patterns);
-            let mut buf = [0u8; 1 << 15];
+            let mut buf = [0u8; 1 << 18]; // 256 KiB
             let mut map = Map {
                 s: ch_s.clone(),
                 map: FxHashMap::default(),


### PR DESCRIPTION
## Summary

Increases the per-worker-thread read buffer from 32 KiB (`1 << 15`) to 256 KiB (`1 << 18`).

## Motivation

Modern NVMe SSDs benefit from 64–256 KiB I/O sizes. A larger buffer means:
- Fewer `read()` syscalls per file
- Less SIMD setup/teardown overhead in `bytecount::count`

The 256 KiB stack allocation per worker thread is negligible.

## Validation

- `cargo check` passes cleanly
- Single-line, low-risk change