### PR TITLE
refactor: replace tabled with local formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -202,12 +202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "globset"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +271,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "tabled",
 ]
 
 [[package]]
@@ -316,39 +309,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "papergrid"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
-dependencies = [
- "bytecount",
- "fnv",
- "unicode-width",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -439,7 +399,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -469,17 +429,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.119"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
@@ -490,49 +439,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabled"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
-dependencies = [
- "papergrid",
- "tabled_derive",
- "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "testing_table"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,4 @@ regex = { version = "1.13.1" }
 rustc-hash = { version = "2.1.3" }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151" }
-tabled = { version = "0.21.0" }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,14 +26,6 @@ use serde::Serialize;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::string::ToString;
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Alignment, Modify, Style,
-        object::{Columns, Rows},
-        style::Border,
-    },
-};
 
 use crate::lang;
 
@@ -106,48 +98,205 @@ fn write_json_pretty(out: &Output) {
     println!("{}", serde_json::to_string_pretty(&out).unwrap());
 }
 
-#[derive(Tabled)]
 struct Row {
-    #[tabled(rename = "Language")]
     language: &'static str,
-    #[tabled(rename = "Files")]
     files: String,
-    #[tabled(rename = "Lines")]
     lines: String,
 }
 
 fn write_table(out: &Output) {
-    let mut data = Vec::new();
+    println!("{}", format_table(out));
+
+    if let Some(elapsed_ms) = out.elapsed_ms {
+        println!("\nTook: {elapsed_ms}ms");
+    }
+}
+
+fn format_table(out: &Output) -> String {
+    let mut rows = Vec::new();
     for lang in &out.languages {
-        data.push(Row {
+        rows.push(Row {
             language: lang.language.as_str(),
             files: lang.num_files.to_formatted_string(&Locale::en),
             lines: lang.num_lines.to_formatted_string(&Locale::en),
         });
     }
 
-    if out.languages.len() != 1 {
-        data.push(Row {
+    let has_total = out.languages.len() != 1;
+    if has_total {
+        rows.push(Row {
             language: "Total",
             files: out.total_num_files.to_formatted_string(&Locale::en),
             lines: out.total_num_lines.to_formatted_string(&Locale::en),
         });
     }
 
-    let mut table = Table::new(&data);
-    table
-        .with(Style::psql())
-        .with(Modify::new(Columns::first()).with(Alignment::left()))
-        .with(Modify::new(Columns::new(1..=2)).with(Alignment::right()))
-        .with(Modify::new(Rows::first()).with(Alignment::left()));
+    let widths = [
+        column_width("Language", rows.iter().map(|row| row.language)),
+        column_width("Files", rows.iter().map(|row| row.files.as_str())),
+        column_width("Lines", rows.iter().map(|row| row.lines.as_str())),
+    ];
 
-    if out.languages.len() != 1 {
-        table.with(Modify::new(Rows::last()).with(Border::new().top('-')));
+    let mut output = vec![format_header(&widths), format_separator(&widths, '+')];
+    for (index, row) in rows.iter().enumerate() {
+        if has_total && index == rows.len() - 1 {
+            output.push(format_separator(&widths, ' '));
+        }
+        output.push(format_row(row, &widths));
     }
 
-    println!("{table}");
+    output.join("\n")
+}
 
-    if let Some(elapsed_ms) = out.elapsed_ms {
-        println!("\nTook: {elapsed_ms}ms");
+fn column_width<'a>(header: &'a str, values: impl Iterator<Item = &'a str>) -> usize {
+    values
+        .map(display_width)
+        .chain(std::iter::once(display_width(header)))
+        .max()
+        .unwrap_or(0)
+        + 2
+}
+
+fn display_width(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn format_header(widths: &[usize; 3]) -> String {
+    [
+        format_left_cell("Language", widths[0]),
+        format_left_cell("Files", widths[1]),
+        format_left_cell("Lines", widths[2]),
+    ]
+    .join("|")
+}
+
+fn format_separator(widths: &[usize; 3], separator: char) -> String {
+    let separator = separator.to_string();
+    [
+        "-".repeat(widths[0]),
+        "-".repeat(widths[1]),
+        "-".repeat(widths[2]),
+    ]
+    .join(&separator)
+}
+
+fn format_row(row: &Row, widths: &[usize; 3]) -> String {
+    [
+        format_left_cell(row.language, widths[0]),
+        format_right_cell(&row.files, widths[1]),
+        format_right_cell(&row.lines, widths[2]),
+    ]
+    .join("|")
+}
+
+fn format_left_cell(value: &str, width: usize) -> String {
+    format!(" {value}{} ", " ".repeat(width - display_width(value) - 2),)
+}
+
+fn format_right_cell(value: &str, width: usize) -> String {
+    format!(" {}{value} ", " ".repeat(width - display_width(value) - 2),)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_table_aligns_rows_and_total() {
+        let output = Output {
+            languages: vec![
+                LangOut {
+                    language: lang::Language::Rust,
+                    num_files: 12,
+                    num_lines: 123,
+                },
+                LangOut {
+                    language: lang::Language::Markdown,
+                    num_files: 3,
+                    num_lines: 45,
+                },
+            ],
+            total_num_files: 15,
+            total_num_lines: 168,
+            elapsed_ms: None,
+        };
+
+        assert_eq!(
+            format_table(&output),
+            concat!(
+                " Language | Files | Lines \n",
+                "----------+-------+-------\n",
+                " Rust     |    12 |   123 \n",
+                " Markdown |     3 |    45 \n",
+                "---------- ------- -------\n",
+                " Total    |    15 |   168 ",
+            )
+        );
+    }
+
+    #[test]
+    fn format_table_omits_total_for_one_language() {
+        let output = Output {
+            languages: vec![LangOut {
+                language: lang::Language::Rust,
+                num_files: 1,
+                num_lines: 9,
+            }],
+            total_num_files: 1,
+            total_num_lines: 9,
+            elapsed_ms: Some(7),
+        };
+
+        assert_eq!(
+            format_table(&output),
+            concat!(
+                " Language | Files | Lines \n",
+                "----------+-------+-------\n",
+                " Rust     |     1 |     9 ",
+            )
+        );
+    }
+
+    #[test]
+    fn format_table_handles_no_languages() {
+        let output = Output {
+            languages: Vec::new(),
+            total_num_files: 0,
+            total_num_lines: 0,
+            elapsed_ms: None,
+        };
+
+        assert_eq!(
+            format_table(&output),
+            concat!(
+                " Language | Files | Lines \n",
+                "----------+-------+-------\n",
+                "---------- ------- -------\n",
+                " Total    |     0 |     0 ",
+            )
+        );
+    }
+
+    #[test]
+    fn format_table_handles_large_formatted_numbers() {
+        let output = Output {
+            languages: vec![LangOut {
+                language: lang::Language::Rust,
+                num_files: 1_234_567,
+                num_lines: 987_654_321,
+            }],
+            total_num_files: 1_234_567,
+            total_num_lines: 987_654_321,
+            elapsed_ms: None,
+        };
+
+        assert_eq!(
+            format_table(&output),
+            concat!(
+                " Language | Files     | Lines       \n",
+                "----------+-----------+-------------\n",
+                " Rust     | 1,234,567 | 987,654,321 ",
+            )
+        );
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -79,7 +79,7 @@ pub fn visit_path_parallel(
                         counter.line_cnt += lines;
                     }
                     Err(err) => {
-                        eprintln!("Error: {:?}: {}", &path, err);
+                        eprintln!("Error: {:?}: {}", path, err);
                     }
                 }
                 WalkState::Continue


### PR DESCRIPTION
## Summary
- replace the `tabled` dependency with a small local formatter
- preserve table alignment and total-row output
- add formatter coverage and fix the Clippy warning in `fs.rs`

## Validation
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test
- cargo build